### PR TITLE
Change Sprint to Jog

### DIFF
--- a/Source/Rule56/Comps/ThingComp_CombatAI.cs
+++ b/Source/Rule56/Comps/ThingComp_CombatAI.cs
@@ -405,7 +405,7 @@ namespace CombatAI.Comps
 //						if (Rand.Chance((sightReader.GetThreat(pawn.Position) - sightReader.GetThreat(cell)) + 0.1f))
 //						{
 							Job job_goto = JobMaker.MakeJob(JobDefOf.Goto, cell);
-							job_goto.locomotionUrgency = LocomotionUrgency.Sprint;
+							job_goto.locomotionUrgency = LocomotionUrgency.Jog;
 							pawn.jobs.ClearQueuedJobs();
 							pawn.jobs.StopAll();
 							pawn.jobs.StartJob(moveJob = job_goto, JobCondition.InterruptForced);
@@ -448,7 +448,7 @@ namespace CombatAI.Comps
 								if (cell != pawnPosition && (prevEnemyDir == Vector2.zero || Rand.Chance(Mathf.Abs(1 - Vector2.Dot(prevEnemyDir, sightReader.GetEnemyDirection(cell).normalized))) || Rand.Chance(sightReader.GetVisibilityToEnemies(pawn.Position) - sightReader.GetVisibilityToEnemies(cell))))
 								{
 									Job job_goto = JobMaker.MakeJob(JobDefOf.Goto, cell);
-									job_goto.locomotionUrgency = LocomotionUrgency.Sprint;
+									job_goto.locomotionUrgency = LocomotionUrgency.Jog;
 									Job job_waitCombat = JobMaker.MakeJob(JobDefOf.Wait_Combat, Rand.Int % 100 + 100);
 									job_waitCombat.checkOverrideOnExpire = true;
 									pawn.jobs.ClearQueuedJobs();
@@ -481,7 +481,7 @@ namespace CombatAI.Comps
 								if (prevEnemyDir == Vector2.zero || Rand.Chance(Mathf.Abs(1 - Vector2.Dot(prevEnemyDir, sightReader.GetEnemyDirection(cell).normalized))) || Rand.Chance(sightReader.GetVisibilityToEnemies(pawn.Position) - sightReader.GetVisibilityToEnemies(cell)))
 								{
 									Job job_goto = JobMaker.MakeJob(JobDefOf.Goto, cell);
-									job_goto.locomotionUrgency = LocomotionUrgency.Sprint;
+									job_goto.locomotionUrgency = LocomotionUrgency.Jog;
 									Job job_waitCombat = JobMaker.MakeJob(JobDefOf.Wait_Combat, Rand.Int % 100 + 100);
 									job_waitCombat.checkOverrideOnExpire = true;
 									pawn.jobs.ClearQueuedJobs();
@@ -551,7 +551,7 @@ namespace CombatAI.Comps
 									if (Rand.Chance(sightReader.GetVisibilityToEnemies(pawn.Position) - sightReader.GetVisibilityToEnemies(cell)) || Rand.Chance(sightReader.GetThreat(pawn.Position) - sightReader.GetThreat(cell)))
 									{
 										Job job_goto = JobMaker.MakeJob(JobDefOf.Goto, cell);
-										job_goto.locomotionUrgency = LocomotionUrgency.Sprint;
+										job_goto.locomotionUrgency = LocomotionUrgency.Jog;
 										Job job_waitCombat = JobMaker.MakeJob(JobDefOf.Wait_Combat, Rand.Int % 100 + 100);
 										pawn.jobs.StartJob(moveJob = job_goto, JobCondition.InterruptForced);
 										pawn.jobs.ClearQueuedJobs();
@@ -715,7 +715,7 @@ namespace CombatAI.Comps
 								Pawn_CustomDutyTracker.CustomPawnDuty custom = CustomDutyUtility.Escort(ally, pawn, 20, 100, 500 * sapperNodes.Count + Rand.Int % 1000);
 								if (custom != null)
 								{
-									custom.duty.locomotion = LocomotionUrgency.Sprint;
+									custom.duty.locomotion = LocomotionUrgency.Jog;
 									comp.duties.StartDuty(custom);
 									escorts.Add(ally);
 								}

--- a/Source/Rule56/CustomDutyUtility.cs
+++ b/Source/Rule56/CustomDutyUtility.cs
@@ -24,7 +24,7 @@ namespace CombatAI
 			}
 			Pawn_CustomDutyTracker.CustomPawnDuty custom = new Pawn_CustomDutyTracker.CustomPawnDuty();
 			custom.duty                  = new PawnDuty(DutyDefOf.Escort, escortee, radius);
-			custom.duty.locomotion       = LocomotionUrgency.Sprint;
+			custom.duty.locomotion       = LocomotionUrgency.Jog;
 			custom.failOnDistanceToFocus = failOnDist;
 			custom.expireAfter           = expireAfter;
 			custom.startAfter            = startAfter;

--- a/Source/Rule56/Patches/PathFinder_Patch.cs
+++ b/Source/Rule56/Patches/PathFinder_Patch.cs
@@ -223,7 +223,7 @@ namespace CombatAI.Patches
 								//					Pawn_CustomDutyTracker.CustomPawnDuty custom = CustomDutyUtility.Escort(ally, pawn, 20, 100, 300 * blocked.Count + Rand.Int % 1000);
 								//					if (custom != null)
 								//					{
-								//						custom.duty.locomotion = LocomotionUrgency.Sprint;
+								//						custom.duty.locomotion = LocomotionUrgency.Jog;
 								//						comp.duties.StartDuty(custom);
 								//					}
 								//				}


### PR DESCRIPTION
 ### Changes
Changes movement speeds in all jobs from Sprint to Jog
### Reasoning
Sprint is much faster than standard pawn combat move speed. It is almost never used in vanilla, while CAI makes it appear quite often. It feels like AI is cheating when they can outrun your pawns despite having identical move speeds, as player pawns have no ability to sprint. 

This makes it impossible to chase down fleeing raiders or ambush someone with melee because they'll always be faster than your colonist.

I suggest using Jog instead, which is same as normal speed of drafted pawns. This makes combat feel smoother and more equal.